### PR TITLE
Refactor custom matchers (closes #45)

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -115,6 +115,10 @@ test('using jest helpers to assert element states', () => {
   expect(() =>
     expect(queryByTestId('count-value')).not.toHaveTextContent('2'),
   ).toThrowError()
+
+  expect(() =>
+    expect({thisIsNot: 'an html element'}).toBeInTheDOM(),
+  ).toThrowError()
 })
 
 test('using jest helpers to check element attributes', () => {

--- a/src/jest-extensions.js
+++ b/src/jest-extensions.js
@@ -52,6 +52,9 @@ function getAttributeComment(name, value) {
 
 const extensions = {
   toBeInTheDOM(received) {
+    if (received) {
+      checkHtmlElement(received)
+    }
     return {
       pass: !!received,
       message: () => {

--- a/src/jest-extensions.js
+++ b/src/jest-extensions.js
@@ -44,28 +44,15 @@ function getAttributeComment(name, value) {
 const extensions = {
   toBeInTheDOM(received) {
     getDisplayName(received)
-    if (received) {
-      return {
-        message: () =>
-          `${matcherHint(
-            '.not.toBeInTheDOM',
-            'received',
-            '',
-          )} Expected the element not to be present` +
-          `\nReceived : ${printReceived(received)}`,
-        pass: true,
-      }
-    } else {
-      return {
-        message: () =>
-          `${matcherHint(
-            '.toBeInTheDOM',
-            'received',
-            '',
-          )} Expected the element to be present` +
-          `\nReceived : ${printReceived(received)}`,
-        pass: false,
-      }
+    return {
+      message: () =>
+        `${matcherHint(
+          `${this.isNot ? '.not' : ''}.toBeInTheDOM`,
+          'received',
+          '',
+        )} Expected the element not to be present` +
+        `\nReceived : ${printReceived(received)}`,
+      pass: !!received,
     }
   },
 
@@ -73,28 +60,15 @@ const extensions = {
     checkHtmlElement(htmlElement)
     const textContent = htmlElement.textContent
     const pass = matches(textContent, htmlElement, checkWith)
-    if (pass) {
-      return {
-        message: () =>
-          assertMessage(
-            '.not.toHaveTextContent',
-            'Expected value not equals to',
-            htmlElement,
-            checkWith,
-          ),
-        pass: true,
-      }
-    } else {
-      return {
-        message: () =>
-          assertMessage(
-            '.toHaveTextContent',
-            'Expected value equals to',
-            htmlElement,
-            checkWith,
-          ),
-        pass: false,
-      }
+    return {
+      message: () =>
+        assertMessage(
+          `${this.isNot ? '.not' : ''}.toHaveTextContent`,
+          `Expected value ${this.isNot ? 'not ' : ''}equals to`,
+          htmlElement,
+          checkWith,
+        ),
+      pass,
     }
   },
 


### PR DESCRIPTION
This is a proposed refactor to the custom matchers code, as briefly discussed in https://github.com/kentcdodds/react-testing-library/pull/44#discussion_r179593891:

- [x] Use common message format across all custom matchers
- [x] Make it easy to adopt the same format in any future matchers
- [x] Simplify code, remove unneeded if/else logic

Closes #45

#### Proposed changes not yet performed (pending discussion)

- [ ] Make each custom matcher a named export, instead of bundling them in an object as default export
- [ ] Better organize in a sub folder with one file per matchers and some utils file for common stuff

#### Pending to be fixed

- [x] Code coverage is not full because `getDisplayName` never gets called during the tests with a class as argument, only with html elements. I wonder if that is expected, given that this library is only dealing with rendered html and not the virtual dom, or is it?