### PR TITLE
test: use mockResolvedValueOnce instead

### DIFF
--- a/src/__tests__/fetch.js
+++ b/src/__tests__/fetch.js
@@ -29,11 +29,7 @@ class Fetch extends React.Component {
 
 test('Fetch makes an API call and displays the greeting when load-greeting is clicked', async () => {
   // Arrange
-  axiosMock.get.mockImplementationOnce(() =>
-    Promise.resolve({
-      data: {greeting: 'hello there'},
-    }),
-  )
+  axiosMock.get.mockResolvedValueOnce({data: {greeting: 'hello there'}})
   const url = '/greeting'
   const {container, getByText} = render(<Fetch url={url} />)
 


### PR DESCRIPTION
**What**: Uses `mockResolvedValueOnce` rather than `mockImplementationOnce`

<!-- Why are these changes necessary? -->

**Why**: Inspired by #83 from @Gpx 

<!-- How were these changes implemented? -->

**How**: GitHub's editor :wink:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
