### PR TITLE
fix(TS): Add missing getAll and queryAll functions to TS definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ facilitate testing implementation details). Read more about this in
   * [`prettyDOM`](#prettydom)
 * [`TextMatch`](#textmatch)
 * [`query` APIs](#query-apis)
+* [`queryAll` and `getAll` APIs](#queryall-and-getall-apis)
 * [Examples](#examples)
 * [FAQ](#faq)
 * [Other Solutions](#other-solutions)
@@ -561,6 +562,16 @@ the `query` API instead:
 ```javascript
 const submitButton = queryByText('submit')
 expect(submitButton).toBeNull() // it doesn't exist
+```
+
+## `queryAll` and `getAll` APIs
+
+Each of the `query` APIs have a corresponsing `queryAll` version that always returns an Array of matching nodes. `getAll` is the same but throws when the array has a length of 0.
+
+```javascript
+const submitButtons = queryAllByText('submit')
+expect(submitButtons).toHaveLength(3) // expect 3 elements
+expect(submitButtons[0]).toBeInTheDOM()
 ```
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "dom-testing-library": "^2.0.0",
+    "dom-testing-library": "^2.3.1",
     "wait-for-expect": "^0.5.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom'
 import {Simulate} from 'react-dom/test-utils'
-import {bindElementToQueries, prettyDOM} from 'dom-testing-library'
+import {getQueriesForElement, prettyDOM} from 'dom-testing-library'
 
 function render(ui, {container = document.createElement('div')} = {}) {
   ReactDOM.render(ui, container)
@@ -14,7 +14,7 @@ function render(ui, {container = document.createElement('div')} = {}) {
       // Intentionally do not return anything to avoid unnecessarily complicating the API.
       // folks can use all the same utilities we return in the first place that are bound to the container
     },
-    ...bindElementToQueries(container),
+    ...getQueriesForElement(container),
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,14 @@
 import {Simulate as ReactSimulate} from 'react-dom/test-utils'
+import {
+  AllByAttribute,
+  AllByText,
+  BoundFunction,
+  GetByAttribute,
+  GetByText,
+  getQueriesForElement,
+  QueryByAttribute,
+  QueryByText,
+} from 'dom-testing-library'
 
 type TextMatchFunction = (content: string, element: HTMLElement) => boolean
 type TextMatch = string | RegExp | TextMatchFunction
@@ -8,38 +18,33 @@ type TextMatchOptions = {
   collapseWhitespace?: boolean
 }
 
-interface RenderResult {
+interface GetsAndQueries {
+  queryByTestId: BoundFunction<QueryByAttribute>
+  queryAllByTestId: BoundFunction<AllByAttribute>
+  getByTestId: BoundFunction<GetByAttribute>
+  getAllByTestId: BoundFunction<AllByAttribute>
+  queryByText: BoundFunction<QueryByText>
+  queryAllByText: BoundFunction<AllByText>
+  getByText: BoundFunction<GetByText>
+  getAllByText: BoundFunction<AllByText>
+  queryByPlaceholderText: BoundFunction<QueryByAttribute>
+  queryAllByPlaceholderText: BoundFunction<AllByAttribute>
+  getByPlaceholderText: BoundFunction<GetByAttribute>
+  getAllByPlaceholderText: BoundFunction<AllByAttribute>
+  queryByLabelText: BoundFunction<QueryByAttribute>
+  queryAllByLabelText: BoundFunction<AllByAttribute>
+  getByLabelText: BoundFunction<GetByAttribute>
+  getAllByLabelText: BoundFunction<AllByAttribute>
+  queryByAltText: BoundFunction<QueryByAttribute>
+  queryAllByAltText: BoundFunction<AllByAttribute>
+  getByAltText: BoundFunction<GetByAttribute>
+  getAllByAltText: BoundFunction<AllByAttribute>
+}
+
+interface RenderResult extends GetsAndQueries {
   container: HTMLDivElement
   rerender: (ui: React.ReactElement<any>) => void
   unmount: VoidFunction
-  queryByTestId: (
-    id: TextMatch,
-    options?: TextMatchOptions,
-  ) => HTMLElement | null
-  getByTestId: (id: TextMatch, options?: TextMatchOptions) => HTMLElement
-  queryByText: (id: TextMatch, options?: TextMatchOptions) => HTMLElement | null
-  getByText: (text: TextMatch, options?: TextMatchOptions) => HTMLElement
-  queryByPlaceholderText: (
-    id: TextMatch,
-    options?: TextMatchOptions,
-  ) => HTMLElement | null
-  getByPlaceholderText: (
-    text: TextMatch,
-    options?: TextMatchOptions,
-  ) => HTMLElement
-  queryByLabelText: (
-    text: TextMatch,
-    options?: TextMatchOptions,
-  ) => HTMLElement | null
-  getByLabelText: (
-    id: TextMatch,
-    options?: {selector?: string} & TextMatchOptions,
-  ) => HTMLElement
-  queryByAltText: (
-    text: TextMatch,
-    options?: TextMatchOptions,
-  ) => HTMLElement | null
-  getByAltText: (text: TextMatch, options?: TextMatchOptions) => HTMLElement
 }
 
 export function render(
@@ -147,3 +152,5 @@ export const fireEvent: FireFunction & FireObject
 export function renderIntoDocument(ui: React.ReactElement<any>): RenderResult
 
 export function cleanup(): void
+
+export function getQueriesForElement(element: HTMLElement): GetsAndQueries


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adds missing TypeScript definitions for the getAll* and queryAll* functions. Also adds type definition for re-exported `getQueriesForElement` function.

**Why**:

These additions more accurately reflect what the library does and they're helpful. I found that I could get rid of some calls to `querySelectorAll` in favor of `queryAllByTestId` in my tests, which was more convenient.

**How**:

Imported and reused the TS definitions from dom-testing-library to bind the get/query functions to the dom element.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
