### PR TITLE
Remove unused import to prevent naming conflict with export

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,7 +5,6 @@ import {
   BoundFunction,
   GetByAttribute,
   GetByText,
-  getQueriesForElement,
   QueryByAttribute,
   QueryByText,
 } from 'dom-testing-library'


### PR DESCRIPTION
**What**:

Removes unused import to avoid naming conflict with export.

**Why**:

Prevents the following error when running tests for a TypeScript-based React app...

```
node_modules/react-testing-library/typings/index.d.ts
(8,3): Import declaration conflicts with local declaration of 'getQueriesForElement'.
```
* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged
* [ ] Added myself to contributors table N/A
