### PR TITLE
docs: add React.Fragment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,10 @@ The containing DOM node of your rendered React Element (rendered using
 `container.querySelector` etc. to inspect the children.
 
 > Tip: To get the root element of your rendered element, use `container.firstChild`.
->> When that root element is a [React Fragment](https://reactjs.org/docs/fragments.html), `container.firstChild` will only get the first child of that Fragment, not the Fragment itself.
+>
+> NOTE: When that root element is a
+> [React Fragment](https://reactjs.org/docs/fragments.html), `container.firstChild`
+> will only get the first child of that Fragment, not the Fragment itself.
 
 #### `debug`
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The containing DOM node of your rendered React Element (rendered using
 `container.querySelector` etc. to inspect the children.
 
 > Tip: To get the root element of your rendered element, use `container.firstChild`.
+>> When that root element is a [React Fragment](https://reactjs.org/docs/fragments.html), `container.firstChild` will only get the first child of that Fragment, not the Fragment itself.
 
 #### `debug`
 


### PR DESCRIPTION
**What**: Add info to readme about `React.Fragment` and its interaction with `container.firstChild`

**Why**: This is a gotcha many people might run into.

**Checklist**:
* [x] Documentation
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table

When rendering a component that has a `React.Fragment` as the root element.
`container.firstChild` will only grab the first child of the fragment, NOT the fragment JSX-tag