### PR TITLE
feat(render): deprecate renderIntoDocument and make it the default

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -43,10 +43,10 @@ tutorial to learn how: http://kcd.im/pull-request
 
 -->
 
-* `react-testing-library` version:
-* `react` version:
-* `node` version:
-* `npm` (or `yarn`) version:
+- `react-testing-library` version:
+- `react` version:
+- `node` version:
+- `npm` (or `yarn`) version:
 
 Relevant code or config
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -22,10 +22,10 @@ tutorial to learn how: http://kcd.im/pull-request
 
 -->
 
-* `react-testing-library` version:
-* `react` version:
-* `node` version:
-* `npm` (or `yarn`) version:
+- `react-testing-library` version:
+- `react` version:
+- `node` version:
+- `npm` (or `yarn`) version:
 
 ### Relevant code or config:
 

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -12,11 +12,9 @@ and feature requests so we recommend not using this medium to ask them here 😁
 
 ## ❓ Support Forums
 
-* React Spectrum
-  https://spectrum.chat/react-testing-library
-* Reactiflux on Discord
-  https://www.reactiflux.com
-* Stack Overflow
+- React Spectrum https://spectrum.chat/react-testing-library
+- Reactiflux on Discord https://www.reactiflux.com
+- Stack Overflow
   https://stackoverflow.com/questions/tagged/react-testing-library
 
 **ISSUES WHICH ARE QUESTIONS WILL BE CLOSED**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,9 +34,11 @@ merge of your pull request!
 
 <!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
-* [ ] Documentation
-* [ ] Tests
-* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
-* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
+- [ ] Documentation
+- [ ] Tests
+- [ ] Ready to be merged
+      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+- [ ] Added myself to contributors table
+      <!-- this is optional, see the contributing guidelines for instructions -->
 
 <!-- feel free to add additional comments -->

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,
-  "jsxBracketSameLine": false
+  "jsxBracketSameLine": false,
+  "proseWrap": "always"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # CHANGELOG
 
-The changelog is automatically updated using [semantic-release](https://github.com/semantic-release/semantic-release).
-You can see it on the [releases page](../../releases).
+The changelog is automatically updated using
+[semantic-release](https://github.com/semantic-release/semantic-release). You
+can see it on the [releases page](../../releases).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,30 +5,30 @@
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+- The use of sexualized language or imagery and unwelcome sexual attention or
   advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
@@ -37,11 +37,11 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
 ## Scope
 
@@ -58,8 +58,9 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at kent+coc@doddsfamily.us. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -67,8 +68,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Thanks for being willing to contribute!
 
-**Working on your first Pull Request?** You can learn how from this _free_ series
-[How to Contribute to an Open Source Project on GitHub][egghead]
+**Working on your first Pull Request?** You can learn how from this _free_
+series [How to Contribute to an Open Source Project on GitHub][egghead]
 
 ## Project setup
 
@@ -20,33 +20,31 @@ Thanks for being willing to contribute!
 > git branch --set-upstream-to=upstream/master master
 > ```
 >
-> This will add the original repository as a "remote" called "upstream,"
-> Then fetch the git information from that remote, then set your local `master`
-> branch to use the upstream master branch whenever you run `git pull`.
-> Then you can make all of your pull request branches based on this `master`
-> branch. Whenever you want to update your version of `master`, do a regular
-> `git pull`.
+> This will add the original repository as a "remote" called "upstream," Then
+> fetch the git information from that remote, then set your local `master`
+> branch to use the upstream master branch whenever you run `git pull`. Then you
+> can make all of your pull request branches based on this `master` branch.
+> Whenever you want to update your version of `master`, do a regular `git pull`.
 
 ## Add yourself as a contributor
 
-This project follows the [all contributors][all-contributors] specification.
-To add yourself to the table of contributors on the `README.md`, please use the
+This project follows the [all contributors][all-contributors] specification. To
+add yourself to the table of contributors on the `README.md`, please use the
 automated script as part of your PR:
 
 ```console
 npm run add-contributor
 ```
 
-Follow the prompt and commit `.all-contributorsrc` and `README.md` in the PR.
-If you've already added yourself to the list and are making
-a new type of contribution, you can run it again and select the added
-contribution type.
+Follow the prompt and commit `.all-contributorsrc` and `README.md` in the PR. If
+you've already added yourself to the list and are making a new type of
+contribution, you can run it again and select the added contribution type.
 
 ## Committing and Pushing changes
 
 Please make sure to run the tests before you commit your changes. You can run
-`npm run test:update` which will update any snapshots that need updating.
-Make sure to include those changes (if they exist) in your commit.
+`npm run test:update` which will update any snapshots that need updating. Make
+sure to include those changes (if they exist) in your commit.
 
 ### opt into git hooks
 
@@ -67,6 +65,7 @@ Please checkout the [the open issues][issues]
 Also, please watch the repo and respond to questions/bug reports/feature
 requests! Thanks!
 
-[egghead]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[egghead]:
+  https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
 [all-contributors]: https://github.com/kentcdodds/all-contributors
 [issues]: https://github.com/kentcdodds/react-testing-library/issues

--- a/cleanup-after-each.js
+++ b/cleanup-after-each.js
@@ -1,0 +1,1 @@
+afterEach(require('./dist').cleanup)

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,5 +26,6 @@ To run the tests, you can run `npm test examples`, or if you're working on a
 specific example, you can run `npm test name-of-your-file`. This will put you
 into Jest's interactive watch mode with a filter based on the name you provided.
 
-[contributing]: https://github.com/kentcdodds/react-testing-library/blob/master/CONTRIBUTING.md
+[contributing]:
+  https://github.com/kentcdodds/react-testing-library/blob/master/CONTRIBUTING.md
 [jest-dom]: https://github.com/gnapse/jest-dom

--- a/examples/__tests__/mock.react-transition-group.js
+++ b/examples/__tests__/mock.react-transition-group.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {CSSTransition} from 'react-transition-group'
-import {render, Simulate} from 'react-testing-library'
+import {render, fireEvent, cleanup} from 'react-testing-library'
 
 function Fade({children, ...props}) {
   return (
@@ -27,6 +27,8 @@ class HiddenMessage extends React.Component {
   }
 }
 
+afterEach(cleanup)
+
 jest.mock('react-transition-group', () => {
   const FakeTransition = jest.fn(({children}) => children)
   const FakeCSSTransition = jest.fn(
@@ -40,7 +42,7 @@ test('you can mock things with jest.mock', () => {
   const {getByText, queryByText} = render(<HiddenMessage initialShow={true} />)
   expect(getByText('Hello world')).toBeTruthy() // we just care it exists
   // hide the message
-  Simulate.click(getByText('Toggle'))
+  fireEvent.click(getByText('Toggle'))
   // in the real world, the CSSTransition component would take some time
   // before finishing the animation which would actually hide the message.
   // So we've mocked it out for our tests to make it happen instantly

--- a/examples/__tests__/react-context.js
+++ b/examples/__tests__/react-context.js
@@ -1,7 +1,9 @@
 import React from 'react'
-import {render} from 'react-testing-library'
+import {render, cleanup} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import {NameContext, NameProvider, NameConsumer} from '../react-context'
+
+afterEach(cleanup)
 
 /**
  * Test default values by rendering a context consumer without a

--- a/examples/__tests__/react-redux.js
+++ b/examples/__tests__/react-redux.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {createStore} from 'redux'
 import {Provider, connect} from 'react-redux'
-import {render, Simulate} from 'react-testing-library'
+import {render, fireEvent, cleanup} from 'react-testing-library'
 
 // counter.js
 class Counter extends React.Component {
@@ -61,6 +61,8 @@ function reducer(state = {count: 0}, action) {
 
 // Now here's what your test will look like:
 
+afterEach(cleanup)
+
 // this is a handy function that I normally make available for all my tests
 // that deal with connected components.
 // you can provide initialState or the entire store that the ui is rendered with
@@ -79,7 +81,7 @@ function renderWithRedux(
 
 test('can render with redux with defaults', () => {
   const {getByTestId, getByText} = renderWithRedux(<ConnectedCounter />)
-  Simulate.click(getByText('+'))
+  fireEvent.click(getByText('+'))
   expect(getByTestId('count-value').textContent).toBe('1')
 })
 
@@ -87,7 +89,7 @@ test('can render with redux with custom initial state', () => {
   const {getByTestId, getByText} = renderWithRedux(<ConnectedCounter />, {
     initialState: {count: 3},
   })
-  Simulate.click(getByText('-'))
+  fireEvent.click(getByText('-'))
   expect(getByTestId('count-value').textContent).toBe('2')
 })
 
@@ -97,8 +99,8 @@ test('can render with redux with custom store', () => {
   const {getByTestId, getByText} = renderWithRedux(<ConnectedCounter />, {
     store,
   })
-  Simulate.click(getByText('+'))
+  fireEvent.click(getByText('+'))
   expect(getByTestId('count-value').textContent).toBe('1000')
-  Simulate.click(getByText('-'))
+  fireEvent.click(getByText('-'))
   expect(getByTestId('count-value').textContent).toBe('1000')
 })

--- a/examples/__tests__/react-router.js
+++ b/examples/__tests__/react-router.js
@@ -2,7 +2,7 @@ import React from 'react'
 import {withRouter} from 'react-router'
 import {Link, Route, Router, Switch} from 'react-router-dom'
 import {createMemoryHistory} from 'history'
-import {render, Simulate} from 'react-testing-library'
+import {render, fireEvent, cleanup} from 'react-testing-library'
 
 const About = () => <div>You are on the about page</div>
 const Home = () => <div>You are home</div>
@@ -29,6 +29,8 @@ function App() {
 
 // Ok, so here's what your tests might look like
 
+afterEach(cleanup)
+
 // this is a handy function that I would utilize for any component
 // that relies on the router being in context
 function renderWithRouter(
@@ -49,7 +51,7 @@ test('full app rendering/navigating', () => {
   // normally I'd use a data-testid, but just wanted to show this is also possible
   expect(container.innerHTML).toMatch('You are home')
   const leftClick = {button: 0}
-  Simulate.click(getByText(/about/i), leftClick)
+  fireEvent.click(getByText(/about/i), leftClick)
   // normally I'd use a data-testid, but just wanted to show this is also possible
   expect(container.innerHTML).toMatch('You are on the about page')
 })

--- a/examples/__tests__/shallow.react-transition-group.js
+++ b/examples/__tests__/shallow.react-transition-group.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {CSSTransition} from 'react-transition-group'
-import {render, Simulate} from 'react-testing-library'
+import {render, fireEvent, cleanup} from 'react-testing-library'
 
 function Fade({children, ...props}) {
   return (
@@ -27,6 +27,8 @@ class HiddenMessage extends React.Component {
   }
 }
 
+afterEach(cleanup)
+
 jest.mock('react-transition-group', () => {
   const FakeCSSTransition = jest.fn(() => null)
   return {CSSTransition: FakeCSSTransition}
@@ -41,7 +43,7 @@ test('you can mock things with jest.mock', () => {
     {in: true, ...defaultProps},
     context,
   )
-  Simulate.click(getByText(/toggle/i))
+  fireEvent.click(getByText(/toggle/i))
   expect(CSSTransition).toHaveBeenCalledWith(
     {in: true, ...defaultProps},
     expect.any(Object),

--- a/examples/__tests__/update-props.js
+++ b/examples/__tests__/update-props.js
@@ -3,7 +3,7 @@
 // that your first call created for you.
 
 import React from 'react'
-import {render} from 'react-testing-library'
+import {render, cleanup} from 'react-testing-library'
 
 let idCounter = 1
 
@@ -18,6 +18,8 @@ class NumberDisplay extends React.Component {
     )
   }
 }
+
+afterEach(cleanup)
 
 test('calling render with the same component on the same container does not remount', () => {
   const {getByTestId, rerender} = render(<NumberDisplay number={1} />)

--- a/other/MAINTAINING.md
+++ b/other/MAINTAINING.md
@@ -4,60 +4,67 @@ This is documentation for maintainers of this project.
 
 ## Code of Conduct
 
-Please review, understand, and be an example of it. Violations of the code of conduct are
-taken seriously, even (especially) for maintainers.
+Please review, understand, and be an example of it. Violations of the code of
+conduct are taken seriously, even (especially) for maintainers.
 
 ## Issues
 
-We want to support and build the community. We do that best by helping people learn to solve
-their own problems. We have an issue template and hopefully most folks follow it. If it's
-not clear what the issue is, invite them to create a minimal reproduction of what they're trying
-to accomplish or the bug they think they've found.
+We want to support and build the community. We do that best by helping people
+learn to solve their own problems. We have an issue template and hopefully most
+folks follow it. If it's not clear what the issue is, invite them to create a
+minimal reproduction of what they're trying to accomplish or the bug they think
+they've found.
 
 Once it's determined that a code change is necessary, point people to
-[makeapullrequest.com](http://makeapullrequest.com) and invite them to make a pull request.
-If they're the one who needs the feature, they're the one who can build it. If they need
-some hand holding and you have time to lend a hand, please do so. It's an investment into
-another human being, and an investment into a potential maintainer.
+[makeapullrequest.com](http://makeapullrequest.com) and invite them to make a
+pull request. If they're the one who needs the feature, they're the one who can
+build it. If they need some hand holding and you have time to lend a hand,
+please do so. It's an investment into another human being, and an investment
+into a potential maintainer.
 
-Remember that this is open source, so the code is not yours, it's ours. If someone needs a change
-in the codebase, you don't have to make it happen yourself. Commit as much time to the project
-as you want/need to. Nobody can ask any more of you than that.
+Remember that this is open source, so the code is not yours, it's ours. If
+someone needs a change in the codebase, you don't have to make it happen
+yourself. Commit as much time to the project as you want/need to. Nobody can ask
+any more of you than that.
 
 ## Pull Requests
 
-As a maintainer, you're fine to make your branches on the main repo or on your own fork. Either
-way is fine.
+As a maintainer, you're fine to make your branches on the main repo or on your
+own fork. Either way is fine.
 
-When we receive a pull request, a travis build is kicked off automatically (see the `.travis.yml`
-for what runs in the travis build). We avoid merging anything that breaks the travis build.
+When we receive a pull request, a travis build is kicked off automatically (see
+the `.travis.yml` for what runs in the travis build). We avoid merging anything
+that breaks the travis build.
 
-Please review PRs and focus on the code rather than the individual. You never know when this is
-someone's first ever PR and we want their experience to be as positive as possible, so be
-uplifting and constructive.
+Please review PRs and focus on the code rather than the individual. You never
+know when this is someone's first ever PR and we want their experience to be as
+positive as possible, so be uplifting and constructive.
 
 When you merge the pull request, 99% of the time you should use the
-[Squash and merge](https://help.github.com/articles/merging-a-pull-request/) feature. This keeps
-our git history clean, but more importantly, this allows us to make any necessary changes to the
-commit message so we release what we want to release. See the next section on Releases for more
-about that.
+[Squash and merge](https://help.github.com/articles/merging-a-pull-request/)
+feature. This keeps our git history clean, but more importantly, this allows us
+to make any necessary changes to the commit message so we release what we want
+to release. See the next section on Releases for more about that.
 
 ## Release
 
-Our releases are automatic. They happen whenever code lands into `master`. A travis build gets
-kicked off and if it's successful, a tool called
-[`semantic-release`](https://github.com/semantic-release/semantic-release) is used to
-automatically publish a new release to npm as well as a changelog to GitHub. It is only able to
-determine the version and whether a release is necessary by the git commit messages. With this
-in mind, **please brush up on [the commit message convention][commit] which drives our releases.**
+Our releases are automatic. They happen whenever code lands into `master`. A
+travis build gets kicked off and if it's successful, a tool called
+[`semantic-release`](https://github.com/semantic-release/semantic-release) is
+used to automatically publish a new release to npm as well as a changelog to
+GitHub. It is only able to determine the version and whether a release is
+necessary by the git commit messages. With this in mind, **please brush up on
+[the commit message convention][commit] which drives our releases.**
 
-> One important note about this: Please make sure that commit messages do NOT contain the words
-> "BREAKING CHANGE" in them unless we want to push a major version. I've been burned by this
-> more than once where someone will include "BREAKING CHANGE: None" and it will end up releasing
-> a new major version. Not a huge deal honestly, but kind of annoying...
+> One important note about this: Please make sure that commit messages do NOT
+> contain the words "BREAKING CHANGE" in them unless we want to push a major
+> version. I've been burned by this more than once where someone will include
+> "BREAKING CHANGE: None" and it will end up releasing a new major version. Not
+> a huge deal honestly, but kind of annoying...
 
 ## Thanks!
 
 Thank you so much for helping to maintain this project!
 
-[commit]: https://github.com/conventional-changelog-archived-repos/conventional-changelog-angular/blob/ed32559941719a130bb0327f886d6a32a8cbc2ba/convention.md
+[commit]:
+  https://github.com/conventional-changelog-archived-repos/conventional-changelog-angular/blob/ed32559941719a130bb0327f886d6a32a8cbc2ba/convention.md

--- a/other/manual-releases.md
+++ b/other/manual-releases.md
@@ -1,9 +1,10 @@
 # manual-releases
 
-This project has an automated release set up. So things are only released when there are
-useful changes in the code that justify a release. But sometimes things get messed up one way or another
-and we need to trigger the release ourselves. When this happens, simply bump the number below and commit
-that with the following commit message based on your needs:
+This project has an automated release set up. So things are only released when
+there are useful changes in the code that justify a release. But sometimes
+things get messed up one way or another and we need to trigger the release
+ourselves. When this happens, simply bump the number below and commit that with
+the following commit message based on your needs:
 
 **Major**
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "files": [
     "dist",
-    "typings"
+    "typings",
+    "cleanup-after-each.js"
   ],
   "keywords": [
     "testing",
@@ -36,22 +37,22 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "dom-testing-library": "^2.3.1",
-    "wait-for-expect": "^0.5.0"
+    "dom-testing-library": "^2.6.0",
+    "wait-for-expect": "^1.0.0"
   },
   "devDependencies": {
-    "@types/react-dom": "^16.0.5",
+    "@types/react-dom": "^16.0.6",
     "axios": "^0.18.0",
     "eslint-import-resolver-jest": "^2.1.1",
     "history": "^4.7.2",
-    "jest-dom": "^1.0.0",
+    "jest-dom": "^1.3.1",
     "jest-in-case": "^1.0.2",
-    "kcd-scripts": "^0.37.0",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
+    "kcd-scripts": "^0.39.1",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
     "react-redux": "^5.0.7",
-    "react-router": "^4.2.0",
-    "react-router-dom": "^4.2.2",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1",
     "react-transition-group": "^2.3.1",
     "redux": "^4.0.0"
   },

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import {render} from '../'
+import {render, cleanup} from '../'
 
 beforeEach(() => {
   jest.spyOn(console, 'log').mockImplementation(() => {})
 })
 
 afterEach(() => {
+  cleanup()
   console.log.mockRestore()
 })
 

--- a/src/__tests__/end-to-end.js
+++ b/src/__tests__/end-to-end.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import {render, wait} from '../'
+import {render, wait, cleanup} from '../'
+
+afterEach(cleanup)
 
 const fetchAMessage = () =>
   new Promise(resolve => {

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {renderIntoDocument, cleanup, fireEvent} from '../'
+import {render, cleanup, fireEvent} from '../'
 
 const eventTypes = [
   {
@@ -141,7 +141,7 @@ eventTypes.forEach(({type, events, elementType, init}) => {
         const ref = React.createRef()
         const spy = jest.fn()
 
-        renderIntoDocument(
+        render(
           React.createElement(elementType, {
             [propName]: spy,
             ref,

--- a/src/__tests__/fetch.js
+++ b/src/__tests__/fetch.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import axiosMock from 'axios'
-import {render, Simulate, wait} from '../'
+import {render, fireEvent, cleanup, wait} from '../'
+
+afterEach(cleanup)
 
 // instead of importing it, we'll define it inline here
 // import Fetch from '../fetch'
@@ -34,7 +36,7 @@ test('Fetch makes an API call and displays the greeting when load-greeting is cl
   const {container, getByText} = render(<Fetch url={url} />)
 
   // Act
-  Simulate.click(getByText('Fetch'))
+  fireEvent.click(getByText('Fetch'))
 
   await wait()
 

--- a/src/__tests__/forms.js
+++ b/src/__tests__/forms.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import {render, Simulate} from '../'
+import {render, fireEvent, cleanup} from '../'
+
+afterEach(cleanup)
 
 function Login({onSubmit}) {
   return (
@@ -32,29 +34,20 @@ function Login({onSubmit}) {
 test('login form submits', () => {
   const fakeUser = {username: 'jackiechan', password: 'hiya! 🥋'}
   const handleSubmit = jest.fn()
-  const {container, getByLabelText, getByText} = render(
-    <Login onSubmit={handleSubmit} />,
-  )
+  const {getByLabelText, getByText} = render(<Login onSubmit={handleSubmit} />)
 
   const usernameNode = getByLabelText(/username/i)
   const passwordNode = getByLabelText(/password/i)
-  const formNode = container.querySelector('form')
   const submitButtonNode = getByText(/submit/i)
 
   // Act
   usernameNode.value = fakeUser.username
   passwordNode.value = fakeUser.password
-  // NOTE: in jsdom, it's not possible to trigger a form submission
-  // by clicking on the submit button. This is really unfortunate.
-  // So the next best thing is to simulate a submit on the form itself
-  // then ensure that there's a submit button.
-  Simulate.submit(formNode)
+  fireEvent.click(submitButtonNode)
 
   // Assert
   expect(handleSubmit).toHaveBeenCalledTimes(1)
   expect(handleSubmit).toHaveBeenCalledWith(fakeUser)
-  // make sure the form is submittable
-  expect(submitButtonNode.type).toBe('submit')
 })
 
 /* eslint jsx-a11y/label-has-for:0 */

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -1,16 +1,16 @@
 import React from 'react'
-import {renderIntoDocument, cleanup} from '../'
+import {render, cleanup} from '../'
 
 afterEach(cleanup)
 
 it('renders button into document', () => {
   const ref = React.createRef()
-  const {container} = renderIntoDocument(<div ref={ref} />)
+  const {container} = render(<div ref={ref} />)
   expect(container.firstChild).toBe(ref.current)
 })
 
 it('access portal elements inside body', () => {
-  const {getByText} = renderIntoDocument(<div />)
+  const {getByText} = render(<div />)
   const portalComponent = document.createElement('div')
   portalComponent.appendChild(document.createTextNode('Hello World'))
   document.body.appendChild(portalComponent)
@@ -31,7 +31,7 @@ it('cleansup document', () => {
     }
   }
 
-  renderIntoDocument(<Test />)
+  render(<Test />)
   cleanup()
   expect(document.body.innerHTML).toBe('')
   expect(spy).toHaveBeenCalledTimes(1)

--- a/src/__tests__/rerender.js
+++ b/src/__tests__/rerender.js
@@ -1,6 +1,8 @@
 import React from 'react'
-import {render} from '../'
+import {render, cleanup} from '../'
 import 'jest-dom/extend-expect'
+
+afterEach(cleanup)
 
 test('rerender will re-render the element', () => {
   const Greeting = props => <div>{props.message}</div>

--- a/src/__tests__/stopwatch.js
+++ b/src/__tests__/stopwatch.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import {render, Simulate} from '../'
+import {render, cleanup, fireEvent} from '../'
+
+afterEach(cleanup)
 
 class StopWatch extends React.Component {
   state = {lapse: 0, running: false}
@@ -42,7 +44,7 @@ const wait = time => new Promise(resolve => setTimeout(resolve, time))
 test('unmounts a component', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})
   const {unmount, getByText, container} = render(<StopWatch />)
-  Simulate.click(getByText('Start'))
+  fireEvent.click(getByText('Start'))
   unmount()
   // hey there reader! You don't need to have an assertion like this one
   // this is just me making sure that the unmount function works.
@@ -51,7 +53,6 @@ test('unmounts a component', async () => {
   // just wait to see if the interval is cleared or not
   // if it's not, then we'll call setState on an unmounted component
   // and get an error.
-  await wait()
   // eslint-disable-next-line no-console
-  expect(console.error).not.toHaveBeenCalled()
+  await wait(() => expect(console.error).not.toHaveBeenCalled())
 })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -50,10 +50,8 @@ export interface RenderResult extends GetsAndQueries {
 
 export function render(
   ui: React.ReactElement<any>,
-  options?: {container: HTMLElement},
+  options?: {container: HTMLElement; baseElement: HTMLElement},
 ): RenderResult
-
-export const Simulate: typeof ReactSimulate
 
 export function wait(
   callback?: () => void,
@@ -149,8 +147,6 @@ type FireObject = {
 }
 
 export const fireEvent: FireFunction & FireObject
-
-export function renderIntoDocument(ui: React.ReactElement<any>): RenderResult
 
 export function cleanup(): void
 


### PR DESCRIPTION
**What**: deprecate renderIntoDocument and make it the default

<!-- Why are these changes necessary? -->

**Why**: Closes #116 
 
<!-- How were these changes implemented? -->

**How**:

- Code refactor
- My son is waiting for me... Otherwise I'd be more informative.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

cc @hnordt @sompylasar 