### PR TITLE
fix(TS): declare optional argument to `debug`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,7 +6,7 @@ type GetsAndQueries = ReturnType<typeof getQueriesForElement>
 
 export interface RenderResult extends GetsAndQueries {
   container: HTMLDivElement
-  debug: () => void
+  debug: (baseElement?: HTMLElement) => void
   rerender: (ui: React.ReactElement<any>) => void
   unmount: () => boolean
 }


### PR DESCRIPTION
**What**:

The `debug` function accepts an optional element as argument, and it was not declared.

**Why**:

Because without this users of this library that also use TypeScript will not be able to use `debug(element)`.

**How**:

By adding the corresponding argument in the type definitions.

**Checklist**:

- [x] Documentation N/A
- [x] Tests N/A
- [x] Ready to be merged
