### PR TITLE
Replace getElementByText with getByText

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,12 +506,12 @@ for a full list as well as default `eventProperties`.
 ```javascript
 import {render, fireEvent} from 'react-testing-library'
 
-const {getElementByText} = render(<Form />)
+const {getByText} = render(<Form />)
 
 // similar to the above example
 // click will bubble for React to see it
 const rightClick = {button: 2}
-fireEvent.click(getElementByText('Submit'), rightClick)
+fireEvent.click(getByText('Submit'), rightClick)
 // default `button` property for click events is set to `0` which is a left click.
 ```
 


### PR DESCRIPTION
Related to https://github.com/kentcdodds/dom-testing-library/pull/82.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Use getByText instead of getElementByText in a code example, which seems like it was a typo.

<!-- Why are these changes necessary? -->

**Why**: getElementByText is not exported by dom-testing-library as far as I'm aware, which could be confusing.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests: N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
