### PR TITLE
fix: Add baseElement to render return type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,6 +6,7 @@ type GetsAndQueries = ReturnType<typeof getQueriesForElement>
 
 export interface RenderResult extends GetsAndQueries {
   container: HTMLDivElement
+  baseElement: HTMLDivElement
   debug: (baseElement?: HTMLElement) => void
   rerender: (ui: React.ReactElement<any>) => void
   unmount: () => boolean

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,8 +5,8 @@ export * from 'dom-testing-library'
 type GetsAndQueries = ReturnType<typeof getQueriesForElement>
 
 export interface RenderResult extends GetsAndQueries {
-  container: HTMLDivElement
-  baseElement: HTMLDivElement
+  container: HTMLElement
+  baseElement: HTMLElement
   debug: (baseElement?: HTMLElement) => void
   rerender: (ui: React.ReactElement<any>) => void
   unmount: () => boolean


### PR DESCRIPTION
**What**:

Add `baseElement` to `render` return type.

**Why**:

Because without it TypeScript code using this library won't be able to use `baseElement`, which is crucial to testing react portals, for example.

**How**:

By adding the `baseElement` property to the type definitions.

**Checklist**:

- [x] Ready to be merged
