### PR TITLE
WIP: add setNativeValue for change event

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -30,7 +30,7 @@ const eventTypes = [
   },
   {
     type: 'Focus',
-    events: ['change', 'input', 'invalid'],
+    events: ['input', 'invalid'],
     elementType: 'input',
   },
   {
@@ -154,3 +154,14 @@ eventTypes.forEach(({type, events, elementType, init}) => {
     })
   })
 })
+
+test('onChange works', () => {
+  const spy = jest.fn()
+
+  const {container} = render(<input onChange={spy} />)
+  const input = container.firstChild
+  fireEvent.change(input, {target: {value: 'c'}})
+  expect(spy).toHaveBeenCalledTimes(1)
+})
+
+/* eslint complexity:0 */

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom'
 import {Simulate} from 'react-dom/test-utils'
-import {getQueriesForElement, prettyDOM} from 'dom-testing-library'
+import {getQueriesForElement, prettyDOM, fireEvent} from 'dom-testing-library'
 
 const mountedContainers = new Set()
 
@@ -45,8 +45,34 @@ function cleanupAtContainer(container) {
   mountedContainers.delete(container)
 }
 
+const originalChange = fireEvent.change
+fireEvent.change = function reactChange(node, init) {
+  if (init && init.target && init.target.hasOwnProperty('value')) {
+    setNativeValue(node, init.target.value)
+  }
+  return originalChange(node, init)
+}
+
+// function written after some investigation here:
+// https://github.com/facebook/react/issues/10135#issuecomment-401496776
+function setNativeValue(element, value) {
+  const {set: valueSetter} =
+    Object.getOwnPropertyDescriptor(element, 'value') || {}
+  const prototype = Object.getPrototypeOf(element)
+  const {set: prototypeValueSetter} =
+    Object.getOwnPropertyDescriptor(prototype, 'value') || {}
+
+  if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+    prototypeValueSetter.call(element, value)
+  } else if (valueSetter) {
+    valueSetter.call(element, value)
+  } else {
+    throw new Error('The given element does not have a value setter')
+  }
+}
+
 // fallback to synthetic events for React events that the DOM doesn't support
-const syntheticEvents = ['change', 'select', 'mouseEnter', 'mouseLeave']
+const syntheticEvents = ['select', 'mouseEnter', 'mouseLeave']
 syntheticEvents.forEach(eventName => {
   document.addEventListener(eventName.toLowerCase(), e => {
     Simulate[eventName](e.target, e)
@@ -56,3 +82,5 @@ syntheticEvents.forEach(eventName => {
 // just re-export everything from dom-testing-library
 export * from 'dom-testing-library'
 export {render, cleanup}
+
+/* eslint complexity:0, func-name-matching:0 */


### PR DESCRIPTION
**What**: This overrides the `fireEvent.change` function to one that allows users to set the target.value using a special `setNativeValue` function.

<!-- Why are these changes necessary? -->

**Why**: (#152) Because React tracks when you set the `value` property on an input to keep track of the node's value. When you dispatch a `change` event, [it checks it's last `value` against the current value](https://github.com/facebook/react/blob/dd5fad29616f706f484938663e93aaadd2a5e594/packages/react-dom/src/client/inputValueTracking.js#L129) and if they're the same it does not call any event handlers (as no change has taken place as far as react is concerned). So we have to set the value in a way that [React's value setter function](https://github.com/facebook/react/blob/dd5fad29616f706f484938663e93aaadd2a5e594/packages/react-dom/src/client/inputValueTracking.js#L78-L81) will not be called, which is where the `setNativeValue` comes into play.

<!-- How were these changes implemented? -->

**How**: Development of the `setNativeValue` function was a team effort: https://github.com/facebook/react/issues/10135#issuecomment-401496776

This is kinda cheating because it's overriding `fireEvent.change`. I think I'd rather we do this within `dom-testing-library` directly.

I'm also not super happy with the API:

```javascript
fireEvent.change(input, {target: {value: 'hi'}})
```

It makes sense to me because in your `onChange` handler if you want the value you'll get it from `event.target.value`, but I worry that this API will make people think they can change other things about the `target` as well... I suppose we could make that work by Object.assigning all `target` properties onto the given `node` (while still treating the `value` property specially) 🤔 

Another thing I've considered is just accepting a `value` option:

```javascript
fireEvent.change(input, {value: 'hi'})
```

But I don't like that because the 2nd argument is _supposed_ to be event init options... I'm open to feedback here.

Also, this PR is incomplete because we still have to handle `select`, `mouseEnter`, and `mouseLeave`. I'm not sure how to handle those. More investigation is needed. 

I'm thinking that we should make these changes in `dom-testing-library` instead of here and we can address each of these one-by-one.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
