### PR TITLE
Add link to example repo using react-testing-library to test a Relay …

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,8 @@ Some included are:
 - [Building a React Tooltip Library](https://www.youtube.com/playlist?list=PLMV09mSPNaQmFLPyrfFtpUdClVfutjF5G)
   by [divyanshu013](https://github.com/divyanshu013) and
   [metagrover](https://github.com/metagrover)
+  
+- [A sample repo using react-testing-library to test a Relay Modern GraphQL app](https://github.com/zth/relay-modern-flow-jest-example)
 
 Feel free to contribute more!
 


### PR DESCRIPTION
…Modern app.

I've made a rather extensive example of how to test a Relay Modern GraphQL app, and I've used `react-testing-library` for all tests. I figured it might be interesting for people to see how you can test a Relay Modern app with `react-testing-library`, mocking queries, and so on. 

Would this be a good link to add to the readme? What do you think? 
