### PR TITLE
Update `debug` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ renders it's HTML directly in the body.
 
 #### `debug`
 
-This method is a shortcut for `console.log(prettyDOM(container))`.
+This method is a shortcut for `console.log(prettyDOM(baseElement))`.
 
 ```javascript
 import {render} from 'react-testing-library'


### PR DESCRIPTION
**What**: Updated docs for `debug` method.

**Why**: The docs say that it pretty-prints the container by default, but in the code it looks like it prints the `baseElement` instead

**How**: N/A

<!-- Have you done all of these things?  -->

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table

