### PR TITLE
Reference about the mocks folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ import React from 'react'
 import {render, fireEvent, cleanup, waitForElement} from 'react-testing-library'
 // this adds custom jest matchers from jest-dom
 import 'jest-dom/extend-expect'
-import axiosMock from 'axios' // the mock lives in a __mocks__ directory
+
+// the mock lives in a __mocks__ directory 
+// to know more about manual mocks, access: https://jestjs.io/docs/en/manual-mocks
+import axiosMock from 'axios' 
 import Fetch from '../fetch' // see the tests for a full implementation
 
 // automatically unmount and cleanup DOM after the test is finished.


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Well, I was struggling to mock the axios response following the main example here. After hours searching it, I've discovered that we can add the __mocks__ folder to mock functions.

<!-- Why are these changes necessary? -->

**Why**:
I've added a small line of comment to reference about the manual-mocks to be more clear and facilitate to the beginners.

<!-- How were these changes implemented? -->

**How**:
I followed the example inside the [jest documentation](https://jestjs.io/docs/en/manual-mocks).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table

<!-- feel free to add additional comments -->
Kent, I'm new into the testing world and I didn't understand very well why in the doc example was created a __mocks__ folder just to mock the .get function. Why not only use the jest.mock('axios') instead? Thank you!
