### PR TITLE
Return rendered component instance

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -55,6 +55,25 @@ test('returns baseElement which defaults to document.body', () => {
   expect(baseElement).toBe(document.body)
 })
 
+test('returns a component instance', () => {
+  // eslint-disable-next-line react/prefer-stateless-function
+  class Greet extends React.Component {
+    render() {
+      const {greeting, subject} = this.props;
+      return (
+        <div>
+          <strong>
+            {greeting} {subject}
+          </strong>
+        </div>
+      )
+    }
+  }
+
+  const {instance} = render(<Greet greeting="Hello" subject="World" />)
+  expect(instance).toBeInstanceOf(Greet)
+})
+
 it('cleansup document', () => {
   const spy = jest.fn()
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,12 @@ function render(ui, {container, baseElement = container, queries} = {}) {
   // they're passing us a custom container or not.
   mountedContainers.add(container)
 
-  ReactDOM.render(ui, container)
+  // eslint-disable-next-line react/no-render-return-value
+  const instance = ReactDOM.render(ui, container)
   return {
     container,
     baseElement,
+    instance,
     // eslint-disable-next-line no-console
     debug: (el = baseElement) => console.log(prettyDOM(el)),
     unmount: () => ReactDOM.unmountComponentAtNode(container),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Return an instance after rendering a component.

<!-- Why are these changes necessary? -->

**Why**:

Testing component implementation details are considered a bad practice for most of components however there are cases where it's important to access a component's instance to make sure that, for example, an instance method or a cross-library integration works correct. This is the reason why I can't drop `enzyme` in favour of this cool library!

I intentionally didn't add documentation for this feature, but if you think it should be documented I will.

<!-- How were these changes implemented? -->

**How**:

[ReactDOM.render()](https://reactjs.org/docs/react-dom.html#render) returns an instance for class components and `null` for functional components.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
