### PR TITLE
removing use of spy to click an event in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ import {render, fireEvent, cleanup, waitForElement} from 'react-testing-library'
 // this adds custom jest matchers from jest-dom
 import 'jest-dom/extend-expect'
 
-// the mock lives in a __mocks__ directory 
+// the mock lives in a __mocks__ directory
 // to know more about manual mocks, access: https://jestjs.io/docs/en/manual-mocks
-import axiosMock from 'axios' 
+import axiosMock from 'axios'
 import Fetch from '../fetch' // see the tests for a full implementation
 
 // automatically unmount and cleanup DOM after the test is finished.
@@ -275,15 +275,14 @@ module.exports = {
 }
 ```
 
-
 #### Export Issue with Babel Versions Lower Than 7
 
-Babel versions lower than 7 throw an error when trying to override the named export
-in the example above. (See
+Babel versions lower than 7 throw an error when trying to override the named
+export in the example above. (See
 [#169](https://github.com/kentcdodds/react-testing-library/issues/169).)
 
 <details>
-<summary>Workaround</summary>    
+<summary>Workaround</summary>
 
 You can use CommonJS modules instead of ES modules, which should work in Node:
 
@@ -296,8 +295,8 @@ const customRender = (node, ...options) => {
 }
 
 module.exports = {
-   ...rtl,
-   render: customRender,
+  ...rtl,
+  render: customRender,
 }
 ```
 
@@ -608,18 +607,9 @@ import {render, cleanup, fireEvent} from 'react-testing-library'
 afterEach(cleanup)
 
 test('clicks submit button', () => {
-  const spy = jest.fn()
-  const {getByText} = render(<button onClick={spy}>Submit</button>)
+  const {getByText} = render(<button onClick={handleClick}>Submit</button>)
 
-  fireEvent(
-    getByText('Submit'),
-    new MouseEvent('click', {
-      bubbles: true, // click events must bubble for React to see it
-      cancelable: true,
-    }),
-  )
-
-  expect(spy).toHaveBeenCalledTimes(1)
+  fireEvent.click(getByText('Submit'))
 })
 ```
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I replaced the spy and MouseEvent bubbling in the README.md

<!-- Why are these changes necessary? -->

**Why**: Handling clicks in this manner didn't work in my project, while `fireEvent.click(...)` did. Also a global search of this repo show the only instance of this handling occurring in the README.md

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ x] Documentation
- [ x] Tests
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
If I'm wrong here, please tell me how. I'm new to open source and would like to learn. If I'm right, this one is such a gimme I feel I should earn a spot as a contributor with a separate task.

This library is awesome, keep up the great work!