### PR TITLE
Remove wait-for-expect from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "dom-testing-library": "^3.9.0",
-    "wait-for-expect": "^1.0.1"
+    "dom-testing-library": "^3.9.0"
   },
   "devDependencies": {
     "@reach/router": "^1.2.1",


### PR DESCRIPTION
**What**:

Remove unused dependency from `package.json`

**Why**:

This package is not used here directly. Dom-testing-library uses it though and declares it there already: https://github.com/kentcdodds/dom-testing-library/blob/master/package.json#L43

On the other hand, in case if dom-testing-library would use a new major version of the dependency, there will be unwanted package duplication, because this line will stay. 

Packages should not declare dependencies on other packages, that they actually do not use.

**Checklist**:

- (N/A) Documentation 
- (N/A) Tests 
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- (N/A) Added myself to contributors table 
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
