### PR TITLE
fix(TS): add hydrate typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -13,12 +13,18 @@ export interface RenderResult extends GetsAndQueries {
   asFragment: () => DocumentFragment
 }
 
+export interface RenderOptions {
+  container: HTMLElement
+  baseElement?: HTMLElement
+  hydrate?: boolean
+}
+
 /**
  * Render into a container which is appended to document.body. It should be used with cleanup.
  */
 export function render(
   ui: React.ReactElement<any>,
-  options?: {container: HTMLElement; baseElement?: HTMLElement},
+  options?: RenderOptions,
 ): RenderResult
 
 /**


### PR DESCRIPTION
**What**:

Add typings for new `hydrate` render option

**Why**:

Enables the new API to be used from TypeScript

**How**:

Pulled existing options into a new `RenderOptions` interface for clarity + reuse and added new member to that.

**Checklist**:

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Ready to be merged - possibly not: see note below
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

**Note**

The current TS definition of `container` has it as a _mandatory_ property (in the _optional_ options object).  This means that it's not possible to write `render(ui, { hydrate: true })`. Users would have to write `render(ui, { container: someNewContainerTheyveMade, hydrate: true })`.  This seems wrong.  Should `container` just be optional?