### PR TITLE
Add explicit `any[]` annotation to Query definition

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@ import {queries, BoundFunction} from 'dom-testing-library'
 export * from 'dom-testing-library'
 
 interface Query extends Function {
-  (container: HTMLElement, ...args): HTMLElement[] | HTMLElement | null
+  (container: HTMLElement, ...args: any[]): HTMLElement[] | HTMLElement | null
 }
 
 interface Queries {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Bug

<!-- Why are these changes necessary? -->

**Why**: The existing typescript definitions fail to compile with `--noImplicitAny` enabled. 

<!-- How were these changes implemented? -->

**How**: I forked the project and tested that the updated declaration compiles correctly.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table 
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
