### PR TITLE
Fix typing of testHook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,14 @@ inside:
 pre-commit
 ```
 
+### Add typings
+
+If your PR introduced some changes in the API, you are more than welcome to
+modify the Typescript type definition to reflect those changes. Just modify the
+`/typings/index.d.ts` file accordingly. If you have never seen Typescript
+definitions before, you can read more about it in its
+[documentation pages](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
+
 ## Help needed
 
 Please checkout the [the open issues][issues]

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -19,6 +19,11 @@ export type RenderResult<Q extends Queries = typeof queries> = {
   asFragment: () => DocumentFragment
 } & {[P in keyof Q]: BoundFunction<Q[P]>}
 
+export type HookResult = {
+  rerender: () => void
+  unmount: () => boolean
+}
+
 export interface RenderOptions<Q extends Queries = typeof queries> {
   container?: HTMLElement
   baseElement?: HTMLElement
@@ -43,7 +48,7 @@ export function render<Q extends Queries>(
 /**
  * Renders a test component that calls back to the test.
  */
-export function testHook(callback: () => void): void
+export function testHook(callback: () => void): HookResult
 
 /**
  * Unmounts React trees that were mounted with render.


### PR DESCRIPTION
Continues pull request #290 

**What**:

Modifies typing declaration of testHook 
Also adds a section to remind contributors to check typings of API

**Checklist**:

- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged
- [N/A] Added myself to contributors table
