### PR TITLE
feat: testHook returns result ref object

### DIFF
--- a/src/__tests__/test-hook.js
+++ b/src/__tests__/test-hook.js
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from 'react'
 import 'jest-dom/extend-expect'
-import {testHook, cleanup} from '../'
+import {testHook, cleanup, act} from '../'
 
 afterEach(cleanup)
 
@@ -59,4 +59,19 @@ test('accepts wrapper option to wrap rendered hook with', () => {
     },
   )
   expect(actual).toBe(12)
+})
+test('returns result ref with latest result from hook execution', () => {
+  function useCounter({initialCount = 0, step = 1} = {}) {
+    const [count, setCount] = React.useState(initialCount)
+    const increment = () => setCount(c => c + step)
+    const decrement = () => setCount(c => c - step)
+    return {count, increment, decrement}
+  }
+
+  const {result} = testHook(useCounter)
+  expect(result.current.count).toBe(0)
+  act(() => {
+    result.current.increment()
+  })
+  expect(result.current.count).toBe(1)
 })

--- a/src/index.js
+++ b/src/index.js
@@ -61,14 +61,23 @@ function render(
   }
 }
 
-function TestHook({callback}) {
-  callback()
+function TestHook({callback, children}) {
+  children(callback())
   return null
 }
 
 function testHook(callback, options = {}) {
+  const result = {
+    current: null,
+  }
   const toRender = () => {
-    const hookRender = <TestHook callback={callback} />
+    const hookRender = (
+      <TestHook callback={callback}>
+        {res => {
+          result.current = res
+        }}
+      </TestHook>
+    )
     if (options.wrapper) {
       return React.createElement(options.wrapper, null, hookRender)
     }
@@ -76,6 +85,7 @@ function testHook(callback, options = {}) {
   }
   const {unmount, rerender: rerenderComponent} = render(toRender())
   return {
+    result,
     unmount,
     rerender: () => {
       rerenderComponent(toRender())

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -19,7 +19,8 @@ export type RenderResult<Q extends Queries = typeof queries> = {
   asFragment: () => DocumentFragment
 } & {[P in keyof Q]: BoundFunction<Q[P]>}
 
-export type HookResult = {
+export type HookResult<TResult> = {
+  result: React.MutableRefObject<TResult>
   rerender: () => void
   unmount: () => boolean
 }
@@ -52,7 +53,10 @@ export function render<Q extends Queries>(
 /**
  * Renders a test component that calls back to the test.
  */
-export function testHook(callback: () => void, options?: Partial<HookOptions>): HookResult
+export function testHook<T>(
+  callback: () => T,
+  options?: Partial<HookOptions>,
+): HookResult<T>
 
 /**
  * Unmounts React trees that were mounted with render.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added ability to access return value of custom hook call without requiring to use closures for it.

<!-- Why are these changes necessary? -->

**Why**: https://github.com/kentcdodds/react-testing-library/issues/295#issuecomment-462800743

<!-- How were these changes implemented? -->

**How**: Using ref object approach similar to `useRef` hook

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table - N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

No tests were harmed by this change which actually surprised me a lot and my current mental capacity is unable to explain how is it possible 🤕 

Fixes #295 