### PR TITLE
Fixed plural typo

### DIFF
--- a/examples/__tests__/react-context.js
+++ b/examples/__tests__/react-context.js
@@ -45,7 +45,7 @@ test('NameProvider composes full name from first, last', () => {
 })
 
 /**
- * A tree containing both a providers and consumer can be rendered normally
+ * A tree containing both a provider and consumer can be rendered normally
  */
 test('NameProvider/Consumer shows name of character', () => {
   const tree = (


### PR DESCRIPTION

**What**:

Fixed a plural typo

**Why**:

Less typos will look more neat and professional.

**Checklist**:

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) "N/A"
- [ ] Tests "N/A"
- [ ] Typescript definitions updated "N/A"
- [x] Ready to be merged
- [ ] Added myself to contributors table

I fixed a critical typo issue