### PR TITLE
feat(act): Support async act 🎉

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,12 +34,11 @@ merge of your pull request!
 
 <!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
-- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs)
+- [ ] Documentation added to the
+      [docs site](https://github.com/alexkrolick/testing-library-docs)
 - [ ] Tests
 - [ ] Typescript definitions updated
 - [ ] Ready to be merged
       <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
-- [ ] Added myself to contributors table
-      <!-- this is optional, see the contributing guidelines for instructions -->
 
 <!-- feel free to add additional comments -->

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "node": ">=8"
   },
   "scripts": {
-    "add-contributor": "kcd-scripts contributors add",
     "build": "kcd-scripts build && kcd-scripts build --bundle --no-clean",
     "lint": "kcd-scripts lint",
     "test": "kcd-scripts test --config=other/jest.config.js",
@@ -43,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.4.2",
-    "dom-testing-library": "^3.18.2"
+    "dom-testing-library": "^3.19.0"
   },
   "devDependencies": {
     "@reach/router": "^1.2.1",
@@ -56,8 +55,8 @@
     "jest-dom": "3.1.3",
     "jest-in-case": "^1.0.2",
     "kcd-scripts": "1.1.2",
-    "react": "^16.8.5",
-    "react-dom": "^16.8.5",
+    "react": "16.9.0-alpha.0",
+    "react-dom": "16.9.0-alpha.0",
     "react-intl": "^2.8.0",
     "react-redux": "6.0.1",
     "react-router": "^5.0.0",

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -1,0 +1,45 @@
+import {asyncAct} from '../act-compat'
+
+jest.mock('react-dom/test-utils', () => ({
+  act: cb => {
+    const promise = cb()
+    return {
+      then() {
+        console.error('blah, do not do this')
+        return promise
+      },
+    }
+  },
+}))
+
+test('async act works even when the act is an old one', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  const callback = jest.fn()
+  await asyncAct(async () => {
+    await Promise.resolve()
+    await callback()
+  })
+  expect(console.error.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+  ],
+]
+`)
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  // and it doesn't warn you twice
+  callback.mockClear()
+  console.error.mockClear()
+
+  await asyncAct(async () => {
+    await Promise.resolve()
+    await callback()
+  })
+  expect(console.error).toHaveBeenCalledTimes(0)
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  console.error.mockRestore()
+})
+
+/* eslint no-console:0 */

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,13 @@ import {
   getQueriesForElement,
   prettyDOM,
   fireEvent as dtlFireEvent,
+  configure as configureDTL,
 } from 'dom-testing-library'
-import act from './act-compat'
+import act, {asyncAct} from './act-compat'
+
+configureDTL({
+  asyncWrapper: asyncAct,
+})
 
 const mountedContainers = new Set()
 
@@ -132,5 +137,9 @@ fireEvent.select = (node, init) => {
 // just re-export everything from dom-testing-library
 export * from 'dom-testing-library'
 export {render, cleanup, fireEvent, act}
+
+// NOTE: we're not going to export asyncAct because that's our own compatibility
+// thing for people using react-dom@16.8.0. Anyone else doesn't need it and
+// people should just upgrade anyway.
 
 /* eslint func-name-matching:0 */


### PR DESCRIPTION
**What**: Add support for async `act`

<!-- Why are these changes necessary? -->

**Why**: Closes #281

<!-- How were these changes implemented? -->

**How**: Unfortunately, we need to do a bit of attempts at polyfilling to ensure we support react-dom@16.8.0 for the foreseeable future. This means that we not only have to polyfill `act` itself, but also polyfill the async support of `act`. So I've done my best to detect whether `act` supports async. I feel pretty good about this solution. I'd rather this than detecting the version number anyway.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Tests N/A
- [x] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Update the dom-testing-library version once this is released: https://github.com/kentcdodds/dom-testing-library/pull/236

<!-- feel free to add additional comments -->
